### PR TITLE
Expand pantry unit options

### DIFF
--- a/components/pantry/PantryAddForm.tsx
+++ b/components/pantry/PantryAddForm.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import {
+  COUNT_UNITS,
   DATE_LABEL_TYPES,
   DATE_LABEL_TYPE_LABELS,
-  PANTRY_UNITS,
+  VOLUME_UNITS,
+  WEIGHT_UNITS,
   type DateLabelType,
   type PantryUnit,
 } from "@/lib/domain/pantry";
 import { useId, useState } from "react";
-
-const units: PantryUnit[] = [...PANTRY_UNITS];
 
 interface PantryAddFormProps {
   onSuccess: () => void;
@@ -133,11 +133,30 @@ export default function PantryAddForm({ onSuccess }: PantryAddFormProps) {
             value={unit}
             onChange={(e) => setUnit(e.target.value as PantryUnit)}
           >
-            {units.map((u) => (
-              <option key={u} value={u}>
-                {u}
-              </option>
-            ))}
+            {/* Count group */}
+            <optgroup label="Count">
+              {COUNT_UNITS.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </optgroup>
+            {/* Weight group */}
+            <optgroup label="Weight">
+              {WEIGHT_UNITS.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </optgroup>
+            {/* Volume group */}
+            <optgroup label="Volume">
+              {VOLUME_UNITS.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </optgroup>
           </select>
         </div>
       </div>

--- a/lib/domain/pantry.ts
+++ b/lib/domain/pantry.ts
@@ -1,4 +1,8 @@
-export const PANTRY_UNITS = ["count", "g", "oz", "ml"] as const;
+export const COUNT_UNITS = ["count"] as const;
+export const WEIGHT_UNITS = ["oz", "lb", "g", "kg"] as const;
+export const VOLUME_UNITS = ["fl oz", "cup", "ml", "l"] as const;
+
+export const PANTRY_UNITS = [...COUNT_UNITS, ...WEIGHT_UNITS, ...VOLUME_UNITS] as const;
 export type PantryUnit = (typeof PANTRY_UNITS)[number];
 
 export const PANTRY_STATUSES = ["ACTIVE", "CONSUMED", "DISCARDED"] as const;


### PR DESCRIPTION
Closes #43

### What
Expands the pantry item unit dropdown to include common weight and volume units.

### Why
The previous list was too limited for real-world pantry items, causing awkward entries.

### How
- Added weight and volume units to the domain constants
- Grouped options with native `<optgroup>` for improved scanability

### Testing
1. Open Add Pantry Item modal
2. Verify expanded unit list is present and grouped
3. Confirm API POST and GET work with new units

No conversions or logic changes introduced.
